### PR TITLE
Added field for last updated to transaction response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,22 +84,22 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.2.3</version>
+			<version>2.6.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.2.3</version>
+			<version>2.6.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.2.3</version>
+			<version>2.6.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
-			<version>2.2.3</version>
+			<version>2.6.5</version>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>

--- a/src/main/java/com/qapital/plaid/client/response/TransactionsResponse.java
+++ b/src/main/java/com/qapital/plaid/client/response/TransactionsResponse.java
@@ -3,11 +3,16 @@ package com.qapital.plaid.client.response;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.qapital.plaid.client.response.joda.AnnotationDateTimeDeserializer;
+import org.joda.time.DateTime;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class TransactionsResponse extends AccountsResponse {
 
-    protected List<Transaction> transactions;
+    private List<Transaction> transactions;
+    private DateTime LastUpdated;
     
     public List<Transaction> getTransactions() {
         return transactions;
@@ -16,5 +21,14 @@ public class TransactionsResponse extends AccountsResponse {
     public void setTransactions(List<Transaction> transactions) {
         this.transactions = transactions;
     }
-    
+
+    @JsonProperty("last_updated")
+    @JsonDeserialize(using = AnnotationDateTimeDeserializer.class)
+    public DateTime getLastUpdated() {
+        return LastUpdated;
+    }
+
+    public void setLastUpdated(DateTime lastUpdated) {
+        LastUpdated = lastUpdated;
+    }
 }

--- a/src/main/java/com/qapital/plaid/client/response/joda/AnnotationDateTimeDeserializer.java
+++ b/src/main/java/com/qapital/plaid/client/response/joda/AnnotationDateTimeDeserializer.java
@@ -1,0 +1,18 @@
+package com.qapital.plaid.client.response.joda;
+
+import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
+import com.fasterxml.jackson.datatype.joda.deser.DateTimeDeserializer;
+import org.joda.time.DateTime;
+
+/**
+ *
+ * Needed since the DateTimeDeserializer does ot have a default constructor to use with annotations
+ * http://stackoverflow.com/questions/38433432/class-com-fasterxml-jackson-datatype-joda-deser-datetimedeserializer-has-no-defa
+ *
+ */
+public class AnnotationDateTimeDeserializer extends DateTimeDeserializer {
+
+    public AnnotationDateTimeDeserializer() {
+        super(DateTime.class, FormatConfig.DEFAULT_DATETIME_PARSER);
+    }
+}


### PR DESCRIPTION
Updated jackson to effective version from client-api.

Was intended to fix the no default constructor issue, but did not help. But we should keep current anyway.